### PR TITLE
Filtering of border nodes relevant for winning during exploration 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ fn explore_with<A: MaxEvenDpa, Q: ExplorationQueue<NodeIndex, A::EdgeLabel>>(
 where
     A::EdgeLabel: Clone + Eq + Ord,
 {
-    let constructor = GameConstructor::new(automaton_spec, queue);
+    let constructor = GameConstructor::new(automaton_spec, queue, options.exploration_filter);
 
     match options.parity_solver {
         Solver::Fpi => solve_with(constructor, FpiSolver::new(), options),
@@ -287,7 +287,7 @@ where
 
     let mut incremental_solver = IncrementalSolver::new(solver);
     loop {
-        constructor.explore(limit);
+        constructor.explore(limit, |_| false);
         let game = constructor.get_game();
         let result = incremental_solver.solve(game);
         let construction_stats = constructor.stats();


### PR DESCRIPTION
The filtering of old Strix has to be reimplemented. Issues to take care of:
- How can the filtering be made more efficient when it is called frequently with small updates?
- How can the exploration queue be easily kept consistent with the current border?